### PR TITLE
`doctype 5` is deprecated, you must now use `doctype html`

### DIFF
--- a/shop/views/main/layout.jade
+++ b/shop/views/main/layout.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html(lang="en")
   head
     title #{store} | #{title}


### PR DESCRIPTION
Fix #9
